### PR TITLE
replace uuid with Node.js based function

### DIFF
--- a/dist/aws-sdk.js
+++ b/dist/aws-sdk.js
@@ -13637,7 +13637,7 @@ var util = {
 
   uuid: {
     v4: function uuidV4() {
-      return require('uuid').v4();
+      return require('crypto').randomUUID();
     }
   },
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -984,7 +984,7 @@ var util = {
    */
   uuid: {
     v4: function uuidV4() {
-      return require('uuid').v4();
+      return require('crypto').randomUUID();
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "jmespath": "^0.16.0",
     "url": "^0.11.3",
     "util": "^0.12.5",
-    "uuid": "^8.3.2",
     "xml2js": "^0.6.2",
     "xmlbuilder": "^10.1.1"
   },
@@ -52,7 +51,7 @@
   "types": "index.d.ts",
   "typings": "index.d.ts",
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 14.17.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Change sets

- replace uuid usage with Node.js based functionr
- drop uuid from direct dependency

This function is available from Node.js 14.17.0, so I just changed lowest version to be supported. 
It should be no issues for consumers, since LTS are either v18 and v20 now. 

https://nodejs.org/api/crypto.html#cryptorandomuuidoptions